### PR TITLE
Bump MarkupSafe to 1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click==6.7
 Flask==0.12.3
 itsdangerous==0.24
 Jinja2==2.10
-MarkupSafe==1.0
+MarkupSafe==1.1
 peewee==3.2.2
 psycopg2-binary==2.8.4
 Werkzeug==0.14.1


### PR DESCRIPTION
Due to https://github.com/pallets/markupsafe/issues/57, version 1.0
will fail to install properly.  This is fixed in 1.1.